### PR TITLE
fixed implied argument to -c flag

### DIFF
--- a/couchdb-backup.sh
+++ b/couchdb-backup.sh
@@ -106,7 +106,7 @@ lines=5000
 attempts=3
 createDBsOnDemand=false
 
-while getopts ":h?H:d:f:u:p:P:l:t:a:c:V?b?B?r?R?" opt; do
+while getopts ":h?H:d:f:u:p:P:l:t:a:c?V?b?B?r?R?" opt; do
     case "$opt" in
         h) usage;;
         b|B) backup=true ;;


### PR DESCRIPTION
Minor problem (just tested your 1.1.4 patch to the couchdb-backup.sh - thanks by the way!) - the '-c' argument was configured to expect an argument. I've just replaced a ":" with a "?" and it now works for me... 